### PR TITLE
Bump version

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl"          : "6.*",
     "name"          : "IO::Socket::Async::SSL",
-    "version"       : "0.1",
+    "version"       : "0.2",
     "description"   : "Provides an API like IO::Socket::Async, but with SSL support.",
     "authors"       : [ "Jonathan Worthington <jnthn@jnthn.net>" ],
     "license"       : "Artistic-2.0",


### PR DESCRIPTION
There are at least two reasons:
1)Package upgrade becomes easier(at least `zef` bases its upgrades on the library version field, not on a git commit).
2)It is not *so* alpha to be `0.1`, at least `0.2` looks better.