### PR TITLE
Gather understandable errors

### DIFF
--- a/lib/IO/Socket/Async/SSL.pm6
+++ b/lib/IO/Socket/Async/SSL.pm6
@@ -4,6 +4,7 @@ use OpenSSL::Ctx;
 use OpenSSL::EVP;
 use OpenSSL::SSL;
 use OpenSSL::Stack;
+use OpenSSL::Err;
 
 # XXX Contribute these back to the OpenSSL binding.
 use OpenSSL::NativeLib;
@@ -509,11 +510,16 @@ class IO::Socket::Async::SSL {
     my constant SSL_ERROR_WANT_WRITE = 3;
     sub check($ssl, $rc, $expected = 0) {
         if $rc < $expected {
-            my $error = OpenSSL::SSL::SSL_get_error($ssl, $rc);
-            unless $error == any(SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE) {
+            my $error = OpenSSL::Err::ERR_get_error();
+            my @log;
+            while ($error != 0|SSL_ERROR_WANT_READ|SSL_ERROR_WANT_WRITE) {
+                @log.push(OpenSSL::Err::ERR_error_string($error, Nil));
+                $error = OpenSSL::Err::ERR_get_error();
+            }
+            if @log.elems != 0 {
                 die X::IO::Socket::Async::SSL.new(
-                    message => OpenSSL::Err::ERR_error_string($error, Nil)
-                );
+                    message => @log.join("\n")
+                )
             }
         }
         $rc


### PR DESCRIPTION
This gives you
```
error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
# Easy to understand and/or google error
```
instead of
```
error:00000001:lib(0):func(0):reason(1) # Oh My Goddess
```

Tests are okay and it shouldn't break anything too.