### PR TITLE
handle deprecated SSL_load_error_strings fixes #14

### DIFF
--- a/lib/IO/Socket/Async/SSL.pm6
+++ b/lib/IO/Socket/Async/SSL.pm6
@@ -91,8 +91,13 @@ my constant NID_subject_alt_name = 85;
 OpenSSL::EVP::EVP_aes_128_cbc();
 
 # On first load of the module, initialize the library.
-OpenSSL::SSL::SSL_load_error_strings();
-OpenSSL::SSL::SSL_library_init();
+try {
+    CATCH {
+        default { OpenSSL::SSL::OPENSSL_init_ssl(0, OpaquePointer); }
+    }
+    OpenSSL::SSL::SSL_library_init();
+    OpenSSL::SSL::SSL_load_error_strings();
+}
 
 # For now, we'll put a lock around all of our interactions with the library.
 # There are smarter things possible.


### PR DESCRIPTION
From https://www.openssl.org/docs/man1.1.0/crypto/SSL_load_error_strings.html

    "The ERR_load_crypto_strings(), SSL_load_error_strings(), and
    ERR_free_strings() functions were deprecated in OpenSSL 1.1.0 by
    OPENSSL_init_crypto() and OPENSSL_init_ssl()."

I've just taken the init code from OpenSSL.