### PR TITLE
Always handle $!shutdown-promise

### DIFF
--- a/lib/IO/Socket/Async/SSL.pm6
+++ b/lib/IO/Socket/Async/SSL.pm6
@@ -625,6 +625,11 @@ class IO::Socket::Async::SSL {
             }
             CATCH {
                 default {
+                    my $ex = $_;
+                    with $!shutdown-promise {
+                        warn "IO::Socket::Async::SSL: Failed to close socket: %s".sprintf($ex.message);
+                        $!shutdown-promise.break();
+                    }
                     $!bytes-received.quit($_);
                 }
             }


### PR DESCRIPTION
When the socket fails to be setup correctly due to warnings like "IO::Socket::Async::SSL: Failed to set temporary DH", then close call may hang on await $!shutdown-promise as that promise is neither kept nor broken.

Break the promise on failure to shutdown correctly and throw another warning.