### PR TITLE
Plumb .native-descriptor through to async socket

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: perl6
 
 perl6:
   - latest
-  - "2017.10"
   - "2018.01"
 
 install:

--- a/lib/IO/Socket/Async/SSL.pm6
+++ b/lib/IO/Socket/Async/SSL.pm6
@@ -926,6 +926,11 @@ class IO::Socket::Async::SSL {
         $!sock.socket-port;
     }
 
+    #| Get the socket native descriptor
+    method native-descriptor() {
+        $!sock.native-descriptor;
+    }
+
     #| Closes the connection. This will await the completion of any
     #| outstanding writes before closing.
     method close(IO::Socket::Async::SSL:D: --> Nil) {


### PR DESCRIPTION
{peer,socket}-{host,port} were already plumbed through to the underlying
IO::Socket::Async object, but native-descriptor was missing.  Trivially
add it.