### PR TITLE
Make `.write`s Promise result return the written bytes

### DIFF
--- a/lib/IO/Socket/Async/SSL.pm6
+++ b/lib/IO/Socket/Async/SSL.pm6
@@ -931,7 +931,7 @@ class IO::Socket::Async::SSL {
                 ));
                 return $p;
             }
-            OpenSSL::SSL::SSL_write($!ssl, $b, $b.bytes);
+            my $ret = OpenSSL::SSL::SSL_write($!ssl, $b, $b.bytes);
             my $p = start {
                 $lib-lock.protect: {
                     self!flush-read-bio();
@@ -939,6 +939,7 @@ class IO::Socket::Async::SSL {
                     # holding of $lib-lock in the code with the assignment.
                     @!outstanding-writes .= grep({ $_ !=== $p });
                 }
+                $ret
             }
             @!outstanding-writes.push($p);
             $p


### PR DESCRIPTION
This helps in building an `IO::Socket::SSL` look-alike on top of `IO::Socket::Async::SSL`.