### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - macOS-latest
           # - windows-latest
         raku-version:
-          - "2021.03"
+          - "2021.07"
           - "latest"
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macos-latest now defaults to an ARM machine. There are no precompiled binaries on offer for Rakudo 2021.03. The first release to available is 2021.07, so we move to that.